### PR TITLE
Correct Typo in Model Implementations Section of Directory Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ task in the corresponding task folder.
 Each model class is decorated by a 
 `@MODEL_REGISTRY.register(name="<model_name>", type="<task_name>")` decorator. 
 To use a model class in CoreNet training or evaluation,
-assign `moels.<task_name>.name = <model_name>` in the YAML configuration.
+assign `models.<task_name>.name = <model_name>` in the YAML configuration.
 
 </td> <td> <pre>
 └── corenet


### PR DESCRIPTION
In the Model Implementations section of the Directory Structure, I've made the following correction:

| from     | to         | 
|--------|--------|
| moels  | models |