### PR TITLE
Correct Typo in CoreNet's and OpenELM's Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ task in the corresponding task folder.
 Each model class is decorated by a 
 `@MODEL_REGISTRY.register(name="<model_name>", type="<task_name>")` decorator. 
 To use a model class in CoreNet training or evaluation,
-assign `moels.<task_name>.name = <model_name>` in the YAML configuration.
+assign `models.<task_name>.name = <model_name>` in the YAML configuration.
 
 </td> <td> <pre>
 └── corenet

--- a/projects/openelm/README.md
+++ b/projects/openelm/README.md
@@ -13,7 +13,7 @@ We provide pretraining, evaluation, instruction tuning, and parameter-efficient 
 
 ## Tokenizer
 
-In our experiments, we used LLamav1/v2 tokenizer. Please download the tokenizer from the [official repository](https://github.com/meta-llama/llama).
+In our experiments, we used LLama v1/v2 tokenizer. Please download the tokenizer from the [official repository](https://github.com/meta-llama/llama).
 
 ## Bias, Risks, and Limitations
 


### PR DESCRIPTION
In the Model Implementations section of the Directory Structure, I've made the following correction:

| **From** |  **To**  | 
|----------|--------|
| moels      | models |

In OpenELM Documentation, I've made the following correction:

|  **From**     |  **To**          |
|-------------|--------------|
| LLamav1/v2 | LLama v1/v2 |