### PR TITLE
Allow applying on all modules, not just immediate children

### DIFF
--- a/corenet/modeling/misc/common.py
+++ b/corenet/modeling/misc/common.py
@@ -216,7 +216,6 @@ def _module_bfs(module:torch.nn.Module, p: list[str], idx=1) -> None:
             
             while stack:
                 idx, module = stack.popleft()
-                
                 for submodule_name, submodule in module.named_children():
                     if idx<len(p) and re.match(p[idx], submodule_name):
                         stack.append((idx+1, submodule))
@@ -228,14 +227,15 @@ def freeze_modules_based_on_opts(
     opts: argparse.Namespace, model: torch.nn.Module, verbose: bool = True
 ) -> torch.nn.Module:
     """
-    Allows for freezing immediate modules and parameters of the model using --model.freeze-modules.
+    Allows for freezing immediate modules and parameters as well as nested modules of the model using --model.freeze-modules.
 
-    --model.freeze-modules should be a list of strings or a comma-separated list of regex expressions.
+    --model.freeze-modules should be a list of strings, a comma-separated list of regex expressions or list of strings with '>' between modules to freeze particular nested layers inside immediate module of the model.
 
     Examples of --model.freeze-modules:
         "conv.*"  # see example below: can freeze all (top-level) conv layers
         "^((?!classifier).)*$"   # freezes everything except for "classifier": useful for linear probing
         "conv1,layer1,layer2,layer3"  # freeze all layers up to layer3
+        "transformer>decoder"  # freeze decoder block inside transformer
 
     >>> model = nn.Sequential(OrderedDict([
           ('conv1', nn.Conv2d(1, 20, 5)),

--- a/corenet/modeling/misc/common.py
+++ b/corenet/modeling/misc/common.py
@@ -216,12 +216,15 @@ def _module_bfs(module:torch.nn.Module, p: list[str], idx=1) -> None:
             
             while stack:
                 idx, module = stack.popleft()
-                for submodule_name, submodule in module.named_children():
-                    if idx<len(p) and re.match(p[idx], submodule_name):
-                        stack.append((idx+1, submodule))
-                        if idx == len(p)-1:
-                            freeze_module(submodule)
-                            logger.info("Freezing module: {} Inside: {}".format(submodule_name,'>'.join(p[:-1])))
+                if idx<len(p):
+                    for submodule_name, submodule in module.named_children():
+                        if re.match(p[idx], submodule_name):
+                            if idx == len(p)-1:
+                                freeze_module(submodule)
+                                logger.info("Freezing module: {} Inside: {}".format(submodule_name,'>'.join(p[:-1])))
+                            else:
+                                stack.append((idx+1, submodule))
+
 
 def freeze_modules_based_on_opts(
     opts: argparse.Namespace, model: torch.nn.Module, verbose: bool = True

--- a/corenet/modeling/misc/common.py
+++ b/corenet/modeling/misc/common.py
@@ -221,7 +221,7 @@ def _module_bfs(module:torch.nn.Module, p: list[str], idx=1) -> None:
                         stack.append((idx+1, submodule))
                         if idx == len(p)-1:
                             freeze_module(submodule)
-                            logger.info("Freezing module: {} Inside: {}".format(submodule_name,'>'.join(p)))
+                            logger.info("Freezing module: {} Inside: {}".format(submodule_name,'>'.join(p[:-1])))
 
 def freeze_modules_based_on_opts(
     opts: argparse.Namespace, model: torch.nn.Module, verbose: bool = True

--- a/corenet/modeling/misc/common.py
+++ b/corenet/modeling/misc/common.py
@@ -244,15 +244,25 @@ def freeze_modules_based_on_opts(
     verbose = verbose and is_master(opts)
 
     if freeze_patterns:
-        # TODO: allow applying on all modules, not just immediate chidren? How?
+        immediate_children_patterns = []
+        nested_modules_patterns = []
+        # separate nested expressions from the rest
+        for p in freeze_patterns:
+            if ">" in p:
+                nested_modules_patterns.append(p.split(">"))
+            else:
+                immediate_children_patterns.append(p)
+
+        
+
         for name, module in model.named_children():
-            if any([re.match(p, name) for p in freeze_patterns]):
+            if any([re.match(p, name) for p in immediate_children_patterns]):
                 freeze_module(module)
                 if verbose:
                     logger.info("Freezing module: {}".format(name))
 
         for name, param in model.named_parameters():
-            if any([re.match(p, name) for p in freeze_patterns]):
+            if any([re.match(p, name) for p in immediate_children_patterns]):
                 param.requires_grad = False
                 if verbose:
                     logger.info("Freezing parameter: {}".format(name))


### PR DESCRIPTION
I've made nested module selection based on the way the CSS children selector works. By using '>' we can now select nested modules.

Example:
```
opts = argparse.Namespace(**{"model.freeze_modules": "model1>ins_model"})

inside_model2 = nn.Sequential(
     OrderedDict([
          ('conv1', nn.Conv2d(1,20,5)),
          ('relu1', nn.ReLU()),
          ('conv2', nn.Conv2d(20,64,5)),
          ('relu2', nn.ReLU())
        ])
)

inside_model = nn.Sequential(
     OrderedDict([
          ('ins_model', inside_model2),
          ('conv1', nn.Conv2d(1,20,5))
        ])
)

model = nn.Sequential(
     OrderedDict([
          ('model1', inside_model),
          ('conv1', nn.Conv2d(20,64,5)),
          ('conv2', nn.Conv2d(20,64,5))
        ])
)

print(freeze_modules_based_on_opts(opts, model))

```

returns:
![example_result](https://github.com/apple/corenet/assets/56601011/e759daa2-2bd1-4270-bdc2-cc0029da5ba9)
