### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyyaml==6.0.1
 # the image used in CI
 torch==2.2.1
 torchvision==0.17.1
-torchtext==0.17.1
+torchtext==0.17.2
 torchaudio==2.2.1
 torchdata==0.7.1
 


### PR DESCRIPTION
To fix pip installation
```
ERROR: Could not find a version that satisfies the requirement torchtext==0.17.1 (from versions: 0.1.1, 0.2.0, 0.2.1, 0.2.3, 0.3.1, 0.4.0, 0.5.0, 0.6.0, 0.16.2, 0.17.2, 0.18.0)
```

