### PR TITLE
Updating coremltools to version 7.2 to support python 3.12.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ torchaudio==2.2.2
 torchdata==0.7.1
 
 # dependency for coremltools
-coremltools==7.1
+coremltools==7.2
 
 # dependency for MSCOCO dataset
 pycocotools==2.0.7


### PR DESCRIPTION
When attempting to install on macOS Sequoya (15) running Python 3.12.6, the dependency coremltools fails to install due to it using an outdated command (imp). Updating to version 7.2 fixes this error.