### PR TITLE
Remove duplicate imports in main_eval_llmadapters.py

### DIFF
--- a/corenet/cli/main_eval_llmadapters.py
+++ b/corenet/cli/main_eval_llmadapters.py
@@ -23,7 +23,7 @@ import json
 import os
 import random
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from tqdm import tqdm
@@ -37,10 +37,6 @@ try:
 except:
     llmadapters = None
 import argparse
-import json
-import re
-from typing import List, Optional, Tuple
-
 import torch
 
 from corenet.options.opts import get_lm_eval_arguments


### PR DESCRIPTION
Removes duplicated imports in `corenet/cli/main_eval_llmadapters.py`:
- Drop duplicate import json and import re
- Consolidate typing imports and add Tuple to the first block
- No functional changes, silences lint noise and keeps imports tidy